### PR TITLE
Remove unused refrence to app insights instrumentation key

### DIFF
--- a/Deployment/Modules/AppInsights/output.tf
+++ b/Deployment/Modules/AppInsights/output.tf
@@ -1,7 +1,3 @@
-output "instrumentation_key" {
-  value = azurerm_application_insights.app_insights.instrumentation_key
-}
-
 output "connection_string" {
   value = azurerm_application_insights.app_insights.connection_string
 }


### PR DESCRIPTION
#### PR Classification
This pull request removes an output variable from the Terraform configuration.

#### PR Summary
The output for "instrumentation_key" has been removed from the Terraform configuration, streamlining the outputs. 
- output.tf: Removed the output for "instrumentation_key".
