### PR TITLE
AB#275597-azurerm version changes

### DIFF
--- a/Deployment/azure.tf
+++ b/Deployment/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.80.0"
+      version = "= 4.81.0"
     }
   }
   required_version = "=1.15.8"


### PR DESCRIPTION
This pull request makes a minor update to the Azure provider version in the Terraform configuration, ensuring consistency and compatibility by locking to version 4.81.0.

* Updated the required `azurerm` provider version to `= 4.81.0` in `Deployment/azure.tf` to ensure the project uses a specific, stable version.