### PR TITLE
275597 Shop Facade AZURERM Version Upgrade to 4.81.0 /main

### DIFF
--- a/Deployment/azure.tf
+++ b/Deployment/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.80.0"
+      version = "= 4.81.0"
     }
   }
   required_version = "=1.15.8"


### PR DESCRIPTION
This pull request updates the Azure provider version constraint in the Terraform configuration to require exactly version 4.81.0 instead of any version greater than or equal to 4.80.0.

- **Dependency management:**
  * Updated the `azurerm` provider version in `Deployment/azure.tf` to require exactly `4.81.0` for improved consistency and reproducibility.