### PR TITLE
IR1376105 Fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -280,6 +280,11 @@ stages:
     - IATdeploy
     displayName: "PreProd Deploy (inc terraform, webapp deploy)"
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+    variables:
+      - name: "AzureADConfiguration.TenantId"
+        value: $(AzureADConfigurationTenantId)
+      - name: "AzureADConfiguration.ClientId"
+        value: $(AzureADConfigurationClientId)
     jobs:
       - template: Deployment/templates/app-deploy.yml
         parameters:
@@ -296,6 +301,11 @@ stages:
     - PreProddeploy
     displayName: "Live Deploy (inc terraform, webapp deploy)"
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+    variables:
+      - name: "AzureADConfiguration.TenantId"
+        value: $(AzureADConfigurationTenantId)
+      - name: "AzureADConfiguration.ClientId"
+        value: $(AzureADConfigurationClientId)
     jobs:
       - template: Deployment/templates/app-deploy.yml
         parameters:


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration to ensure that Azure Active Directory (Azure AD) configuration variables are explicitly set for both the PreProd and Live deployment stages. This helps maintain consistent authentication settings across deployments.

Pipeline configuration improvements:

* Added `AzureADConfiguration.TenantId` and `AzureADConfiguration.ClientId` variables to the PreProd deployment stage in `azure-pipelines.yml` to ensure Azure AD settings are available during deployment.
* Added `AzureADConfiguration.TenantId` and `AzureADConfiguration.ClientId` variables to the Live deployment stage in `azure-pipelines.yml` for consistent Azure AD configuration.