### PR TITLE
Feature/275597 dotnet 10 upgrade

### DIFF
--- a/Deployment/Modules/Webapp/main.tf
+++ b/Deployment/Modules/Webapp/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_linux_web_app" "webapp_service" {
 
   site_config {
     application_stack {
-      dotnet_version = "9.0"
+      dotnet_version = "10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -44,7 +44,7 @@ resource "azurerm_linux_web_app_slot" "staging" {
 
   site_config {
     application_stack {
-      dotnet_version = "9.0"
+      dotnet_version = "10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -69,7 +69,7 @@ resource "azurerm_linux_web_app" "adds_mock_webapp_service" {
 
   site_config {
     application_stack {
-      dotnet_version = "9.0"
+      dotnet_version = "10.0"
     }
     always_on  = true
     ftps_state = "Disabled"

--- a/Deployment/azure.tf
+++ b/Deployment/azure.tf
@@ -2,10 +2,10 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.14.0"
+      version = "= 4.81.0"
     }
   }
-  required_version = "=1.10.4"
+  required_version = "=1.15.8"
   backend "azurerm" {
     key            = "terraform.deployment.tfplan"
     container_name = "tfstate"

--- a/Deployment/azure.tf
+++ b/Deployment/azure.tf
@@ -5,7 +5,7 @@ terraform {
       version = "= 4.81.0"
     }
   }
-  required_version = "=1.15.8"
+  required_version = "=1.10.4"
   backend "azurerm" {
     key            = "terraform.deployment.tfplan"
     container_name = "tfstate"

--- a/Deployment/templates/app-deploy.yml
+++ b/Deployment/templates/app-deploy.yml
@@ -29,7 +29,7 @@ parameters:
   default: "ImageOverride -equals ubuntu-latest"
 - name: SdkVersion
   type: string
-  default: '9.0.x'
+  default: '10.0.x'
 # Set the pipeline retention period. Typically used after a successful live deployment.
 - name: RetainPipeline
   type: boolean

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -4,7 +4,7 @@ parameters:
   type: string
 - name: SdkVersion
   type: string
-  default: '9.0.x'
+  default: '10.0.x'
 
 jobs:
 - job: UnitTestsAndCodeCoverage
@@ -13,7 +13,7 @@ jobs:
   displayName: "Dotnet Test and Publish Code Coverage"
   steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 9.0.x sdk'
+      displayName: 'Use .NET 10.0.x sdk'
       inputs:
         packagetype: sdk
         version: ${{ parameters.SdkVersion }}
@@ -81,7 +81,7 @@ jobs:
         arguments: '-buildNumber "$(Build.BuildNumber)" -solutionDirectory "$(Build.SourcesDirectory)\src\UKHO.ShopFacade.API\" -UKHOAssemblyCompany "$env:UKHOAssemblyCompany" -UKHOAssemblyCopyright "$(UKHOAssemblyCopyright)" -UKHOAssemblyVersionPrefix "$env:UKHOAssemblyVersionPrefix" -UKHOAssemblyProduct "$env:UKHOAssemblyProduct"'
 
     - task: UseDotNet@2
-      displayName: 'Use .NET 9.0.x sdk'
+      displayName: 'Use .NET 10.0.x sdk'
       inputs:
         packageType: sdk
         version: ${{ parameters.SdkVersion }}
@@ -144,7 +144,7 @@ jobs:
   displayName: "Dotnet Build publish ADDS Mock Service"
   steps: 
     - task: UseDotNet@2
-      displayName: 'Use .NET 9.0.x sdk'
+      displayName: 'Use .NET 10.0.x sdk'
       inputs:
         packageType: sdk
         version: ${{ parameters.SdkVersion }}
@@ -199,7 +199,7 @@ jobs:
   displayName: "Publish FunctionalTests Artifact"
   steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 9.0.x sdk'
+      displayName: 'Use .NET 10.0.x sdk'
       inputs:
         packageType: sdk
         version: ${{ parameters.SdkVersion }}

--- a/Deployment/templates/continuous-testing.yml
+++ b/Deployment/templates/continuous-testing.yml
@@ -3,7 +3,7 @@ parameters:
     type: string
   - name: SdkVersion
     type: string
-    default: '9.0.x'
+    default: '10.0.x'
 
 steps:
   - task: DownloadBuildArtifacts@0

--- a/Deployment/terraform_conditional_run.ps1
+++ b/Deployment/terraform_conditional_run.ps1
@@ -11,7 +11,7 @@ cd $env:AGENT_BUILDDIRECTORY/terraformartifact
 terraform --version
 
 Write-output "Executing terraform scripts for deployment in $workSpace enviroment"
-terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
+terraform init -upgrade -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
 if ( !$? ) { echo "Something went wrong during terraform initialization"; throw "Error" }
 
 Write-output "Selecting workspace"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ variables:
   - name: CoverageThresholdLimit
     value: "90"
   - name: SdkVersion
-    value: "9.x"
+    value: "10.x"
   - name: AgentPoolNameAppDeploy
     value: "Azure-UKHO-Engineering"
   - name: AgentPoolDemands

--- a/src/UKHO.ADDS.Mocks.ShopFacade/UKHO.ADDS.Mocks.ShopFacade.csproj
+++ b/src/UKHO.ADDS.Mocks.ShopFacade/UKHO.ADDS.Mocks.ShopFacade.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/UKHO.ShopFacade.API/UKHO.ShopFacade.API.csproj
+++ b/src/UKHO.ShopFacade.API/UKHO.ShopFacade.API.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -12,12 +12,12 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.34.5" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.17" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.10" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SharpCompress" Version="0.50.0" />
     <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />

--- a/src/UKHO.ShopFacade.Common/UKHO.ShopFacade.Common.csproj
+++ b/src/UKHO.ShopFacade.Common/UKHO.ShopFacade.Common.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
   </ItemGroup>

--- a/tests/UKHO.ShopFacade.API.FunctionalTests/UKHO.ShopFacade.API.FunctionalTests.csproj
+++ b/tests/UKHO.ShopFacade.API.FunctionalTests/UKHO.ShopFacade.API.FunctionalTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -14,12 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.17" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.86.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">

--- a/tests/UKHO.ShopFacade.API.UnitTests/UKHO.ShopFacade.API.UnitTests.csproj
+++ b/tests/UKHO.ShopFacade.API.UnitTests/UKHO.ShopFacade.API.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/UKHO.ShopFacade.Common.UnitTests/UKHO.ShopFacade.Common.UnitTests.csproj
+++ b/tests/UKHO.ShopFacade.Common.UnitTests/UKHO.ShopFacade.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" /> 
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">


### PR DESCRIPTION
This pull request upgrades the solution from .NET 9.0 to .NET 10.0, updating all related infrastructure, build, and deployment configurations, as well as NuGet package dependencies. The changes ensure that all projects, pipelines, and infrastructure components are compatible with .NET 10.0 and the latest Azure provider versions.

**.NET 10.0 Upgrade Across Solution**

* All project files (`.csproj`) updated to target `net10.0` instead of `net9.0` for main, mock, common, and test projects. [[1]](diffhunk://#diff-3de70ff5a264dee23e3169c9f2bfea94dde9b0af1e725c60ede20ce7c984bae3L5-R5) [[2]](diffhunk://#diff-a61b39f0cc556fc3758937ce5af7b0ea7ffed132bcfdd67ff2fab6fb1893b41eL1-R4) [[3]](diffhunk://#diff-7f651cae2e6c84a16f6c1a94110e13a9a0d0c5b378e41735beb551435cfeefdbL1-R14) [[4]](diffhunk://#diff-0b729837f114d98a4bb11e2a1d97b11a2ee679bb6f2a54219ae6af214482a278L1-R4) [[5]](diffhunk://#diff-fe54a98e5a9fae4e9e984109ba16798a320a4413b829aecea3d628ffe65d9a3eL4-R4) [[6]](diffhunk://#diff-25273bad3c66c896824a26d30fa448b284f4195fc8f95632fe2f9e3e890721e3L1-R4)
* Azure web app resources in `main.tf` updated to use `dotnet_version = "10.0"` for all environments (production, staging, mock). [[1]](diffhunk://#diff-817e3f63b4d854cbfecf71e1dc598e7cd8bbb50afd4b9b3ebcc925bc4534e215L21-R21) [[2]](diffhunk://#diff-817e3f63b4d854cbfecf71e1dc598e7cd8bbb50afd4b9b3ebcc925bc4534e215L47-R47) [[3]](diffhunk://#diff-817e3f63b4d854cbfecf71e1dc598e7cd8bbb50afd4b9b3ebcc925bc4534e215L72-R72)
* Pipeline and template files updated to reference `10.0.x` for the SDK version and display names, ensuring build agents use .NET 10.0. [[1]](diffhunk://#diff-8940d5230c0466ac3c94da82f08c66005b31dc66be267f5067ab1e37495554b9L32-R32) [[2]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL7-R7) [[3]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL16-R16) [[4]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL84-R84) [[5]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL147-R147) [[6]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL202-R202) [[7]](diffhunk://#diff-11c6e2cb83badb8c03697bd6a3d4f2e205a6e4bda8479d04938e0b346010d4bdL6-R6) [[8]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L61-R61)

**Dependency Updates**

* Major NuGet package versions updated from `9.x` to `10.x` for Microsoft libraries in all affected projects, with some additional package version bumps (e.g., `Serilog.Sinks.File`, `Microsoft.Identity.Client`). [[1]](diffhunk://#diff-a61b39f0cc556fc3758937ce5af7b0ea7ffed132bcfdd67ff2fab6fb1893b41eL15-R20) [[2]](diffhunk://#diff-7f651cae2e6c84a16f6c1a94110e13a9a0d0c5b378e41735beb551435cfeefdbL1-R14) [[3]](diffhunk://#diff-0b729837f114d98a4bb11e2a1d97b11a2ee679bb6f2a54219ae6af214482a278L17-R22) [[4]](diffhunk://#diff-25273bad3c66c896824a26d30fa448b284f4195fc8f95632fe2f9e3e890721e3L21-R21)

**Infrastructure and Tooling Updates**

* Azure Terraform provider updated from `4.14.0` to `4.81.0` in `azure.tf`.
* Terraform initialization script now uses the `-upgrade` flag to ensure provider plugins are updated.

These changes collectively ensure the codebase, build pipelines, and infrastructure are aligned with .NET 10.0 and current dependency best practices.